### PR TITLE
Fix build on systems where '/bin/sh' is not 'bash'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ abc/arch_flags
 *~
 .cabal-sandbox
 cabal.sandbox.config
+abc-build
+galois-abcBridge-*.tar.bz2

--- a/scripts/setup-abc.sh
+++ b/scripts/setup-abc.sh
@@ -5,8 +5,8 @@ set -e
 
 echo "Setting up ABC tree for abcBridge version ${PACKAGE_VERSION:-undefined}..."
 
-if [[ -z "${PACKAGE_VERSION}" ]]; then
-  if [[ -d abc-build ]]; then
+if [ -z "${PACKAGE_VERSION}" ]; then
+  if [ -d abc-build ]; then
     echo ""
     echo "Package version not defined; assuming compatible ABC sources are already present in directory abc-build"
   else
@@ -42,7 +42,7 @@ else
 
   PACKAGE_VERSION=${PACKAGE_VERSION:-"$ABC_VERSION"}
 
-  if [[ "$ABC_VERSION" != "$PACKAGE_VERSION" ]]; then
+  if [ "$ABC_VERSION" != "$PACKAGE_VERSION" ]; then
     echo ""
     echo "The ABC source version $ABC_VERSION does not match the abcBridge package version $PACKAGE_VERSION."
     echo ""


### PR DESCRIPTION
On recent Debian based systems '/bin/sh' is not 'bash', and so
Bash-isms such as '[[ ... ]]' tests are not supported. An alternative
solution would be to instead use 'bash' to interpret the build
scripts, by editing 'Setup.hs'.

Also, add some build related Git ignores.

p.s. This is Nathan the new intern. I assume I'm supposed to have push access to these Galois SAW-related GitHub repos.
