### PR TITLE
Add a custom-setup

### DIFF
--- a/abcBridge.cabal
+++ b/abcBridge.cabal
@@ -36,6 +36,12 @@ source-repository head
   type: git
   location: https://github.com/GaloisInc/abcBridge.git
 
+custom-setup
+  setup-depends: base
+               , directory
+               , filepath
+               , Cabal
+
 library
 
   Hs-source-dirs:       src


### PR DESCRIPTION
I had some trouble with `cabal new-build` in `cabal-install-1.24` due to the lack of a `custom-setup` stanza which explicitly stated the dependencies.