### PR TITLE
fall back to non-hardcoded path to find executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ try a 32-bit build if you have trouble with the 64-bit build.
 The main task of the build system is to retrieve and build the ABC C
 sources before building the Haskell bridge.  We do this by downloading
 the latest version of a branch of the ABC project from BitBucket.  See
-"scripts/setup-abc.sh" for the logic relating to this step, including
+["Setup.hs"](./Setup.hs) for the logic relating to this step, including
 the URL from which the sources are fetched.  If you run "cabal sdist",
 ABC sources will be fetched and unpacked, and then repacked into a
 combined source distribution with the Haskell code.  The resulting

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ try a 32-bit build if you have trouble with the 64-bit build.
 The main task of the build system is to retrieve and build the ABC C
 sources before building the Haskell bridge.  We do this by downloading
 the latest version of a branch of the ABC project from BitBucket.  See
-["Setup.hs"](./Setup.hs) for the logic relating to this step, including
+[Setup.hs](./Setup.hs) for the logic relating to this step, including
 the URL from which the sources are fetched.  If you run "cabal sdist",
 ABC sources will be fetched and unpacked, and then repacked into a
 combined source distribution with the Haskell code.  The resulting

--- a/abcBridge.cabal
+++ b/abcBridge.cabal
@@ -36,6 +36,7 @@ custom-setup
   setup-depends: base
                , directory
                , filepath
+               , filemanip
                , Cabal
 
 library

--- a/scripts/setup-abc.sh
+++ b/scripts/setup-abc.sh
@@ -12,16 +12,23 @@ set -x
 # so we can include relevant *.h files
 #
 # Note: fully-qualified 'find' is referenced to work around a problem building
-# under MinGW where unqualified 'find' refers to the Win32 utility of the same name
+# under MinGW where unqualified 'find' refers to the Win32 utility of the same name.
+# If 'find' isn't available on this path, we can fall back to letting the system pick
+# the appropriate executable.
+
+find_bin=/usr/bin/find
+if [ ! -x /usr/bin/find ]; then
+  find_bin=find
+fi
 
 if [ ! -e scripts/abc-incl-dirs.txt ]; then
-  /usr/bin/find abc-build/src -type d > scripts/abc-incl-dirs.txt
+  $find_bin abc-build/src -type d > scripts/abc-incl-dirs.txt
 fi
 
 if [ ! -e scripts/abc-sources.txt ]; then
   # touch the listing file we are about to produce so that it will appear in the file listing!
   touch scripts/abc-sources.txt
-  /usr/bin/find abc-build -type f | sed -e '/\/\.hg\//d' -e '/\.hgignore$/d' -e '/\.o$/d' -e '/\.a$/d' -e '/\.dll$/d' -e '/\.lib$/d' > scripts/abc-sources.txt
+  $find_bin abc-build -type f | sed -e '/\/\.hg\//d' -e '/\.hgignore$/d' -e '/\.o$/d' -e '/\.a$/d' -e '/\.dll$/d' -e '/\.lib$/d' > scripts/abc-sources.txt
 fi
 
 # Make sure the build scripts are executable


### PR DESCRIPTION
Hardcoding /usr/bin/find causes failures on e.g. NixOS, where executables are not on the standard paths.

Fixes #11 

@atomb I'm also working on a `Setup.hs`-based fix, but tested this and it works for me.