### PR TITLE
Build `abc` binary as part of build process

### DIFF
--- a/scripts/build-abc.sh
+++ b/scripts/build-abc.sh
@@ -66,4 +66,4 @@ case "$OS" in
 esac
 
 cd abc-build
-make -j$NPROC ARCHFLAGS="-DABC_LIB $A" ABC_USE_NO_PTHREADS=1 ABC_USE_NO_READLINE=1 libabc.a
+make -j$NPROC ARCHFLAGS="-DABC_LIB $A" ABC_USE_NO_PTHREADS=1 ABC_USE_NO_READLINE=1 libabc.a abc


### PR DESCRIPTION
Sometimes it's useful to have, and it only takes a tiny bit of extra
time to link the executable once we've built the library.