### PR TITLE
Support building with GHC 9.2

### DIFF
--- a/src/Data/ABC/AIG.hs
+++ b/src/Data/ABC/AIG.hs
@@ -48,7 +48,12 @@ module Data.ABC.AIG
 import Prelude ()
 import Prelude.Compat hiding (and, or, not)
 
-import Foreign
+import Foreign.ForeignPtr
+import Foreign.Marshal.Array
+import Foreign.Marshal.Alloc
+import Foreign.Marshal.Utils
+import Foreign.Ptr
+import Foreign.Storable
 
 import Control.Exception
 import Control.Monad.Compat

--- a/src/Data/ABC/GIA.hs
+++ b/src/Data/ABC/GIA.hs
@@ -63,7 +63,11 @@ import qualified Data.AIG.Trace as Tr
 import qualified Data.Vector.Storable as SV
 import qualified Data.Vector.Unboxed as V
 import qualified Data.Vector.Unboxed.Mutable as VM
-import Foreign hiding (void, xor)
+import Foreign.ForeignPtr
+import Foreign.Marshal.Alloc
+import Foreign.Marshal.Array
+import Foreign.Ptr
+import Foreign.Storable
 import System.Directory
 
 import Data.ABC.Internal.ABC

--- a/tests/Tests/Basic.hs
+++ b/tests/Tests/Basic.hs
@@ -30,7 +30,7 @@ basic_tests proxy@(ABC.Proxy f) = f $
       ABC.SomeGraph g <- ABC.newGraph proxy
       let n = ABC.Network g [ABC.falseLit g]
       assertEqual "test_false" [False] =<< ABC.evaluate n []
-  , testProperty "test_constant"$ \b -> ioProperty $do
+  , testProperty "test_constant"$ \b -> ioProperty $ do
       ABC.SomeGraph g <- ABC.newGraph proxy
       let n = ABC.Network g [ABC.constant g b]
       (==[b]) <$> ABC.evaluate n []


### PR DESCRIPTION
In GHC 9.2, `Data.Bits` now exports an `And` data type, which clashes with the `And` used in `Data.ABC.{AIG,GIA}`. To avoid this issue, I no longer import the `Foreign` module wholesale (which re-exports `Data.Bits`), but instead import individual modules in the `Foreign.*` module hierarchy.

Also, GHC 9.2 now includes `-Woperator-whitespace-ext-conflict` as a part of `-Wall`, which causes `Tests.Basic` to warn when built with 9.2. Fortunately, fixing the warning is as simple as adding a space after a `$` character.