### PR TITLE
`build-abc.sh`: Add AArch64 macOS configuration

### DIFF
--- a/scripts/build-abc.sh
+++ b/scripts/build-abc.sh
@@ -20,6 +20,7 @@ case "$OS" in
     case "$ARCH" in
       "I386") A="-m32 -DLIN -DSIZEOF_VOID_P=4 -DSIZEOF_LONG=4 -DSIZEOF_INT=4" ;;
       "X86_64") A="-m64 -fPIC -DLIN64 -DSIZEOF_VOID_P=8 -DSIZEOF_LONG=8 -DSIZEOF_INT=4" ;;
+      "AArch64") A="-m64 -fPIC -DLIN64 -DSIZEOF_VOID_P=8 -DSIZEOF_LONG=8 -DSIZEOF_INT=4" ;;
       *) echo "Unknown architecture: $ARCH" ; exit 2 ;;
     esac
     NPROC=$(sysctl -n hw.ncpu) ;;


### PR DESCRIPTION
Fixes #20.