### PR TITLE
Support building with `Cabal-3.14.*`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "abc-build"]
 	path = abc-build
 	url = https://github.com/GaloisInc/abc.git
+[submodule "deps/aig"]
+	path = deps/aig
+	url = https://github.com/GaloisInc/aig.git

--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,3 @@
 packages:
     abcBridge.cabal
+    deps/aig


### PR DESCRIPTION
Doing so fixes https://github.com/GaloisInc/abcBridge/issues/23.

While I was in town, I also vendored in `aig` as a submodule to make it easier to build this library locally. Doing so fixes #21 as well.